### PR TITLE
Add Build caching for CI/CT time speedups

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,9 +11,7 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v2
     - name: Build core features
       run: cargo build --verbose
     - name: Build all features


### PR DESCRIPTION
[`Swatinem/rust-cache@v2`](https://github.com/Swatinem/rust-cache) is a GitHub Action which takes advantage of GitHubs free build caching feature to speed up CI/CT runs.

This might not yet be an issue for `concoct`, but as features get added and tests get written, CI times grow accordingly. From a quick, non-scientific measurement, CI times could improve by up to 4x for simple changes (from >2min to ~30s).

If this PR gets accepted, please consider squasing the PR instead of merging it normally - I was lazy and tested CI times on my main branch by changing some files back and forth, leading to more commits than necessary :P  